### PR TITLE
Fixed small grammar error

### DIFF
--- a/POPreferences/Resources/PreferenceOrganizer2.plist
+++ b/POPreferences/Resources/PreferenceOrganizer2.plist
@@ -184,7 +184,7 @@
 			<key>cell</key>
 			<string>PSGroupCell</string>
 			<key>footerText</key>
-			<string>© 2013-2014 Karen Tsai (angelXwind), Eliz, ilendemli, insanj.</string>
+			<string>© 2013-2014 Karen Tsai (angelXwind), Eliz, ilendemli, and insanj.</string>
 		</dict>
 	</array>
 	<key>title</key>


### PR DESCRIPTION
A series of nouns would not be Karen Tsai (angelXwind), Eliz, ilendemli, insanj. It would be Karen Tsai (angelXwind), Eliz, ilendmli, and insanj. (small fix that has been bugging me ;P)