### PR TITLE
Crash fix after entering multitasking and algorithm adjustment

### DIFF
--- a/PreferenceOrganizer2.xm
+++ b/PreferenceOrganizer2.xm
@@ -318,7 +318,7 @@ static void PO2InitPrefs() {
 	NSMutableArray* specifiers = [[NSMutableArray alloc] initWithArray:((PSListController *)self).specifiers];
 	
 	// Now begin organising specifiers that appear with this method...
-	if (shouldShowAppleApps) {
+	/*if (shouldShowAppleApps) {
 		NSMutableArray *itemsToReallyRemove = [[NSMutableArray alloc] init];
 		NSMutableArray *itemsToReallyAdd = [[NSMutableArray alloc] init];
 		for (int i = 0; i < [specifiers count]; i++) {
@@ -353,7 +353,7 @@ static void PO2InitPrefs() {
 				[((PSListController *)self).specifiers replaceObjectAtIndex:i withObject:appleSpecifier];
 			}
 		}
-	}
+	}*/
 
 	if (shouldShowAppStoreApps) {
 		int thirdPartyID = 0;


### PR DESCRIPTION
AFAIK, the root cause of crashing after entering multitasking and opening Preferences app again is due to Apple’s Third Party applications that their corresponding PSSpecifier object would be re-added when refreshing 3rd-party bundles occurred. This process conflicts with UITableView’s data source check between before and after the table is updated as those added specifiers would be the excess. So the fix is to prevent them for re-adding when they are supposed to.

Secondly, the workaround for `-[_reallyLoadThirdPartySpecifiersForProxies:withCompletion:]` may be simplified; make uses of existing specifiers ivars as demonstrated in the code.