### PR TITLE
Fixed Launching Tweak URLs (Revision)

### DIFF
--- a/PreferenceOrganizer2.h
+++ b/PreferenceOrganizer2.h
@@ -17,7 +17,6 @@
 @end
 
 @interface TweakSpecifiersController : PSListController
-+ (id)sharedInstance;
 @end
 
 @interface AppStoreAppSpecifiersController : PSListController


### PR DESCRIPTION
Remove TweakSpecifiersController sharedInstance.  Resolve controller in preferenceOrganizerOpenTweakPane: instead.  Also, replace bridge transfer with deprecated (but iOS 6-friendly) stringByReplacingPercentEscapesUsingEncoding.